### PR TITLE
Download REL fork over https instead of git

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ flair~=0.10
 syntok~=1.4.4
 torch>=1.5.0,!=1.8.*
 
-git+git://github.com/chriskamphuis/REL # Change to regular REL after PR has been merged
+git+https://github.com/chriskamphuis/REL # Change to regular REL after PR has been merged
 setuptools~=60.2.0
 tqdm~=4.64.0
 requests~=2.28.0


### PR DESCRIPTION
Installing the requirements failed on my PC. I think it is because downloading a requirement over the git protocol requires authentication, whereas https does not.